### PR TITLE
Relax level-id requirement to SHOULD, infer default 93

### DIFF
--- a/draft-aboba-avtcore-hevc-webrtc
+++ b/draft-aboba-avtcore-hevc-webrtc
@@ -152,8 +152,9 @@ INTERNET-DRAFT          H.265 Profile for WebRTC            24 July 2023
    optional parameters.  To improve interoperability, the following
    parameter settings are specified:
 
-   level-id: Implementations MUST include this parameter within SDP and
-   MUST interpret it when receiving it.
+   level-id: Implementations SHOULD include this parameter within SDP and
+   MUST interpret it when receiving it. If no level-id is present, a
+   value of 93 (i.e., level 3.1) MUST be inferred.
 
    max-fps, max-cpb, max-dpb, and max-br:
 


### PR DESCRIPTION
as described in
  https://www.rfc-editor.org/rfc/rfc7798.html#section-7.1

Fixes #1